### PR TITLE
Fix hyperlink to "Derived Data Types" page

### DIFF
--- a/mpi/index.md
+++ b/mpi/index.md
@@ -21,7 +21,7 @@ tutorial: "Message Passing Interface (MPI)"
     * [Non-blocking Message Passing Routines](non_blocking)
 8. [Exercise 2](exercise_2)
 9. [Collective Communication Routines](collective_communication_routines)
-10. [Derived Data Types](derived_data_types)
+10. [Derived Data Types](derived_data_type)
 11. [Group and Communicator Management Routines](management_routines)
 12. [Virtual Topologies](virtual_topologies)
 13. [A Brief Word on MPI-2 and MPI-3](mpi2_mpi3)


### PR DESCRIPTION
The "Derived Data Types" hyperlink - currently pointing to
https://hpc-tutorials.llnl.gov/mpi/derived_data_types - returns
a 404 error because the filename was changed in https://github.com/LLNL/HPC-Tutorials/commit/ccf95c6b5f907c4f4925e375a2d933ec378191d6.

This PR fixes said hyperlink.

Signed-off-by: Abrar Rahman Protyasha <aprotyas@u.rochester.edu>