### PR TITLE
Minor fixes

### DIFF
--- a/posix/example_code/hello_arg1.c
+++ b/posix/example_code/hello_arg1.c
@@ -34,7 +34,7 @@ messages[1] = "French: Bonjour, le monde!";
 messages[2] = "Spanish: Hola al mundo";
 messages[3] = "Klingon: Nuq neH!";
 messages[4] = "German: Guten Tag, Welt!"; 
-messages[5] = "Russian: Zdravstvuyte, mir!";
+messages[5] = "Russian: Zdravstvuy, mir!";
 messages[6] = "Japan: Sekai e konnichiwa!";
 messages[7] = "Latin: Orbis, te saluto!";
 

--- a/posix/example_code/hello_arg2.c
+++ b/posix/example_code/hello_arg2.c
@@ -36,7 +36,7 @@ messages[1] = "French: Bonjour, le monde!";
 messages[2] = "Spanish: Hola al mundo";
 messages[3] = "Klingon: Nuq neH!";
 messages[4] = "German: Guten Tag, Welt!"; 
-messages[5] = "Russian: Zdravstvytye, mir!";
+messages[5] = "Russian: Zdravstvuy, mir!";
 messages[6] = "Japan: Sekai e konnichiwa!";
 messages[7] = "Latin: Orbis, te saluto!";
 

--- a/posix/passing_args.md
+++ b/posix/passing_args.md
@@ -51,7 +51,7 @@ Thread 1: French: Bonjour, le monde!
 Thread 2: Spanish: Hola al mundo
 Thread 3: Klingon: Nuq neH!
 Thread 4: German: Guten Tag, Welt!
-Thread 5: Russian: Zdravstvytye, mir!
+Thread 5: Russian: Zdravstvuy, mir!
 Thread 6: Japan: Sekai e konnichiwa!
 Thread 7: Latin: Orbis, te saluto!
 ```
@@ -110,7 +110,7 @@ Thread 1: French: Bonjour, le monde!  Sum=1
 Thread 2: Spanish: Hola al mundo  Sum=3
 Thread 3: Klingon: Nuq neH!  Sum=6
 Thread 4: German: Guten Tag, Welt!  Sum=10
-Thread 5: Russian: Zdravstvytye, mir!  Sum=15
+Thread 5: Russian: Zdravstvuy, mir!  Sum=15
 Thread 6: Japan: Sekai e konnichiwa!  Sum=21
 Thread 7: Latin: Orbis, te saluto!  Sum=28
 ```

--- a/posix/passing_args.md
+++ b/posix/passing_args.md
@@ -11,12 +11,11 @@ All arguments must be passed by reference and cast to `(void *)`.
 
 Question: Given their non-deterministic start-up and scheduling, how can you safely pass data to newly created threads? 
 
-<detail>
+<details>
   <summary>Answer (Click to view.)</summary>
 
   *Make sure that all passed data is thread safe - that it can not be changed by other threads.  The three examples that follow demonstrate dos and don'ts.*
-
-</detail>
+</details>
 
 ####  Example 1 - Thread Argument Passing
 

--- a/posix/samples/hello_arg1.c
+++ b/posix/samples/hello_arg1.c
@@ -34,7 +34,7 @@ messages[1] = "French: Bonjour, le monde!";
 messages[2] = "Spanish: Hola al mundo";
 messages[3] = "Klingon: Nuq neH!";
 messages[4] = "German: Guten Tag, Welt!"; 
-messages[5] = "Russian: Zdravstvuyte, mir!";
+messages[5] = "Russian: Zdravstvuy, mir!";
 messages[6] = "Japan: Sekai e konnichiwa!";
 messages[7] = "Latin: Orbis, te saluto!";
 

--- a/posix/samples/hello_arg1.out
+++ b/posix/samples/hello_arg1.out
@@ -11,6 +11,6 @@ Thread 1: French: Bonjour, le monde!
 Thread 2: Spanish: Hola al mundo
 Thread 3: Klingon: Nuq neH!
 Thread 4: German: Guten Tag, Welt!
-Thread 5: Russian: Zdravstvytye, mir!
+Thread 5: Russian: Zdravstvuy, mir!
 Thread 6: Japan: Sekai e konnichiwa!
 Thread 7: Latin: Orbis, te saluto!

--- a/posix/samples/hello_arg2.c
+++ b/posix/samples/hello_arg2.c
@@ -50,7 +50,7 @@ messages[1] = "French: Bonjour, le monde!";
 messages[2] = "Spanish: Hola al mundo";
 messages[3] = "Klingon: Nuq neH!";
 messages[4] = "German: Guten Tag, Welt!"; 
-messages[5] = "Russian: Zdravstvytye, mir!";
+messages[5] = "Russian: Zdravstvuy, mir!";
 messages[6] = "Japan: Sekai e konnichiwa!";
 messages[7] = "Latin: Orbis, te saluto!";
 

--- a/posix/samples/hello_arg2.out
+++ b/posix/samples/hello_arg2.out
@@ -11,6 +11,6 @@ Thread 1: French: Bonjour, le monde!  Sum=1
 Thread 2: Spanish: Hola al mundo  Sum=3
 Thread 3: Klingon: Nuq neH!  Sum=6
 Thread 4: German: Guten Tag, Welt!  Sum=10
-Thread 5: Russian: Zdravstvytye, mir!  Sum=15
+Thread 5: Russian: Zdravstvuy, mir!  Sum=15
 Thread 6: Japan: Sekai e konnichiwa!  Sum=21
 Thread 7: Latin: Orbis, te saluto!  Sum=28

--- a/posix/stack_management.md
+++ b/posix/stack_management.md
@@ -9,7 +9,7 @@ author: Blaise Barney, Lawrence Livermore National Laboratory
 
 [`pthread_attr_getstacksize(attr, stacksize)`](man/pthread_attr_getstacksize.txt)
 
-[pthread_attr_setstacksize](man/pthread_attr_setstacksize.txt) (attr, addr, stacksize)
+[`pthread_attr_setstacksize(attr, addr, stacksize)`](man/pthread_attr_setstacksize.txt)
 
 [`pthread_attr_getstackaddr(attr, stackaddr)`](man/pthread_attr_getstackaddr.txt)
 

--- a/posix/what_are_pthreads.md
+++ b/posix/what_are_pthreads.md
@@ -17,7 +17,7 @@ In order to take full advantage of the capabilities provided by threads, a stand
 The POSIX standard has continued to evolve and undergo revisions, including the Pthreads specification.
 
 Some useful links:
-* [standards.ieee.org/findstds/standard/1003.1-2008.html](http://standards.ieee.org/findstds/standard/1003.1-2008.html)
-* www.opengroup.org/austin/papers/posix_faq.html
+* [standards.ieee.org/ieee/1003.1/7101/](https://standards.ieee.org/ieee/1003.1/7101/)
+* [www.opengroup.org/austin/papers/posix_faq.html)(http://www.opengroup.org/austin/papers/posix_faq.html)
 
 Pthreads are defined as a set of C language programming types and procedure calls, implemented with a `pthread.h` header/include file and a thread library - though this library may be part of another library, such as `libc`, in some implementations.


### PR DESCRIPTION
Using the "-te" conjugation is a more "formal" way to address someone, which doesn't make sense to use for objects (see [wikipedia](https://ru.wikipedia.org/wiki/Hello_World_(%D0%B7%D0%BD%D0%B0%D1%87%D0%B5%D0%BD%D0%B8%D1%8F))). You're also missing the "u" in some of these.